### PR TITLE
Add missing api version into example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ can be rendered with this jsonnet:
 ```jsonnet
 {
   local k = (import "github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet"),
-  foo: k.apps.deployment.new(name="foo", containers=[
+  foo: k.apps.v1.deployment.new(name="foo", containers=[
     k.core.v1.container.new(name="foo", image="foo/bar")
   ])
 }


### PR DESCRIPTION
Hi,

I started to play with k8s-alpha few days ago. Very powerfull and readable!

I just meet this little mistake.