### PR TITLE
docs: remove kausal-shim reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Then put the following into `lib/k.libsonnet`:
 
 ```
 
-> If you happen to use `ksonnet-lib/kausal.libsonnet`, also add:
->
-> ```jsonnet
-> + (import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")
-> ```
-
 #### Standalone
 
 ```bash


### PR DESCRIPTION
kausal.libsonnet now includes a compatibility layer based on this shim.

ref: https://github.com/grafana/jsonnet-libs/pull/426